### PR TITLE
Simplify scala version and make it a bit easier to start testing

### DIFF
--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -1,6 +1,6 @@
 import Dependencies._
 
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.13.1"
 
 lazy val root = (project in file("."))
   .settings(

--- a/scala/project/Dependencies.scala
+++ b/scala/project/Dependencies.scala
@@ -1,14 +1,14 @@
 import sbt._
 
 object Dependencies {
-  private lazy val akkaHttpVersion: String = "10.1.8"
-  private lazy val akkaVersion: String = "2.5.21"
+  private lazy val akkaHttpVersion: String = "10.1.11"
+  private lazy val akkaVersion: String = "2.6.4"
   lazy val `akka-actor` = "com.typesafe.akka" %% "akka-actor" % akkaVersion
   lazy val `akka-http` = "com.typesafe.akka" %% "akka-http" % akkaHttpVersion
   lazy val `akka-http-testkit` = "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpVersion % Test
   lazy val `akka-http-spray-json` = "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpVersion
   lazy val `akka-stream` = "com.typesafe.akka" %% "akka-stream" % akkaVersion
   lazy val `akka-stream-testkit` = "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion % Test
-  lazy val `mysql-connector-java` = "mysql" % "mysql-connector-java" % "8.0.15" % Runtime
-  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.6"
+  lazy val `mysql-connector-java` = "mysql" % "mysql-connector-java" % "8.0.19" % Runtime
+  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.1.1"
 }

--- a/scala/project/build.properties
+++ b/scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version = 1.3.10

--- a/scala/src/main/scala/liftpasspricing/LiftPassPricing.scala
+++ b/scala/src/main/scala/liftpasspricing/LiftPassPricing.scala
@@ -19,7 +19,7 @@ class LiftPassPricing extends HttpApp with JsonSupport {
 
   override def routes: Route =
     path("prices") {
-      (put & parameters('cost, 'type)) { (liftPassCost, liftPassType) =>
+      (put & parameters(Symbol("cost"), Symbol("type"))) { (liftPassCost, liftPassType) =>
         val statement = connection.prepareStatement(
           "INSERT INTO `base_price` (type, cost) VALUES (?, ?) " +
             "ON DUPLICATE KEY UPDATE cost = ?")

--- a/scala/src/main/scala/liftpasspricing/LiftPassPricing.scala
+++ b/scala/src/main/scala/liftpasspricing/LiftPassPricing.scala
@@ -37,17 +37,16 @@ class LiftPassPricing extends HttpApp with JsonSupport {
         val result = costStatement.executeQuery()
         result.next()
 
-        var reduction: Int = 0
-        var isHoliday: Boolean = false
         if (Try(req("age").toInt < 6).getOrElse(false)) {
           complete(Cost(0))
         } else {
-          reduction = 0
           if (req("type") != "night") {
             val holidays = connection.createStatement().executeQuery(
               "SELECT * FROM `holidays`"
             )
 
+            var isHoliday: Boolean = false
+            var reduction: Int = 0
             while (holidays.next) {
               val holiday: LocalDate = holidays.getDate(1).toLocalDate
               if (req.contains("date")) {

--- a/scala/src/test/scala/liftpasspricing/LiftPassPricingSpec.scala
+++ b/scala/src/test/scala/liftpasspricing/LiftPassPricingSpec.scala
@@ -18,12 +18,12 @@ class LiftPassPricingSpec extends AnyFlatSpec with ScalatestRouteTest with JsonS
     }
   }
 
-  "Lift pass pricing api" should "does something" in withLiftPassPricing { app =>
+  it should "does something" in withLiftPassPricing { app =>
 
-    Get("/prices") ~> app ~> check { // construct some proper url parameters
+    Get("/prices?type=1jour") ~> app ~> check {
 
-      val putSomethingHere = Cost(0)
-      responseAs[Cost] shouldBe putSomethingHere
+      val exptectedResult = Cost(35) // change this to make the test pass
+      responseAs[Cost] shouldBe exptectedResult
     }
   }
 

--- a/scala/src/test/scala/liftpasspricing/LiftPassPricingSpec.scala
+++ b/scala/src/test/scala/liftpasspricing/LiftPassPricingSpec.scala
@@ -2,12 +2,12 @@ package liftpasspricing
 
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers._
 
 import scala.util.Try
 
-class LiftPassPricingSpec extends FlatSpec with ScalatestRouteTest with JsonSupport {
+class LiftPassPricingSpec extends AnyFlatSpec with ScalatestRouteTest with JsonSupport {
 
   def withLiftPassPricing(testCode: Route => Any): Unit = {
     val liftPassPrincing = new LiftPassPricing()


### PR DESCRIPTION
This pull request apply same changes than theses commits to Scala code base:
 - 9199b912d72419a93cb727586fa3af33292b9a78 : `simplify ts version`
 - f16ab5cd1c4c5e86c442af3449538638d76bddf8 : `make it a bit easier to start testing`

It also upgrade dependencies to last versions.