### PR TITLE
fix: start spark server only once to avoid raceconditions in unit tests

### DIFF
--- a/java/src/test/java/dojo/liftpasspricing/PricesTest.java
+++ b/java/src/test/java/dojo/liftpasspricing/PricesTest.java
@@ -5,9 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.sql.Connection;
 import java.sql.SQLException;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import io.restassured.RestAssured;
 import io.restassured.path.json.JsonPath;
@@ -15,15 +13,15 @@ import spark.Spark;
 
 public class PricesTest {
 
-    private Connection connection;
+    private static Connection connection;
 
-    @BeforeEach
-    public void createPrices() throws SQLException {
+    @BeforeAll
+    public static void createPrices() throws SQLException {
         connection = Prices.createApp();
     }
 
-    @AfterEach
-    public void stopApplication() throws SQLException {
+    @AfterAll
+    public static void stopApplication() throws SQLException {
         Spark.stop();
         connection.close();
     }


### PR DESCRIPTION
Hi Johan

This is just another PR for the master branch fixing the same problem like in the with_tests branch.

bye, roland
