### PR TITLE
Update scala dependencies

### DIFF
--- a/scala/.scalafmt.conf
+++ b/scala/.scalafmt.conf
@@ -1,3 +1,3 @@
 maxColumn = 120
 runner.dialect = scala213
-version = 3.4.3
+version = 3.7.12

--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -1,20 +1,20 @@
-ThisBuild / scalaVersion := "2.13.8"
+ThisBuild / scalaVersion := "2.13.11"
 
 lazy val root = (project in file("."))
   .settings(
     name := "lift-pass-pricing",
     description := "Lift-Pass-Pricing refactoring kata",
 
-    libraryDependencies += "com.typesafe.akka" %% "akka-actor-typed" % "2.6.19",
-    libraryDependencies += "com.typesafe.akka" %% "akka-http" % "10.2.9",
-    libraryDependencies += "com.typesafe.akka" %% "akka-http-spray-json" % "10.2.9",
-    libraryDependencies += "com.typesafe.akka" %% "akka-stream" % "2.6.19",
+    libraryDependencies += "org.apache.pekko" %% "pekko-actor-typed" % "1.0.1",
+    libraryDependencies += "org.apache.pekko" %% "pekko-http" % "1.0.0",
+    libraryDependencies += "org.apache.pekko" %% "pekko-http-spray-json" % "1.0.0",
+    libraryDependencies += "org.apache.pekko" %% "pekko-stream" % "1.0.1",
 
-    libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.11" % Runtime,
-    libraryDependencies += "mysql" % "mysql-connector-java" % "8.0.28" % Runtime,
+    libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.4.7" % Runtime,
+    libraryDependencies += "mysql" % "mysql-connector-java" % "8.0.33" % Runtime,
 
-    libraryDependencies += "com.typesafe.akka" %% "akka-actor-testkit-typed" % "2.6.19" % Test,
-    libraryDependencies += "com.typesafe.akka" %% "akka-http-testkit" % "10.2.9" % Test,
-    libraryDependencies += "com.typesafe.akka" %% "akka-stream-testkit" % "2.6.19" % Test,
-    libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.11" % Test
+    libraryDependencies += "org.apache.pekko" %% "pekko-actor-testkit-typed" % "1.0.1" % Test,
+    libraryDependencies += "org.apache.pekko" %% "pekko-http-testkit" % "1.0.0" % Test,
+    libraryDependencies += "org.scalatest" %% "scalatest-shouldmatchers" % "3.2.16" % Test,
+    libraryDependencies += "org.scalatest" %% "scalatest-funspec" % "3.2.16" % Test
   )

--- a/scala/project/build.properties
+++ b/scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.6.2
+sbt.version = 1.9.4

--- a/scala/project/plugins.sbt
+++ b/scala/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")

--- a/scala/src/main/resources/logback.xml
+++ b/scala/src/main/resources/logback.xml
@@ -1,8 +1,9 @@
 <configuration>
-
+    <!-- This is a development logging configuration that logs to standard out, for an example of a production
+        logging config, see the Pekko docs: https://pekko.apache.org/docs/pekko/current/typed/logging.html#logback -->
     <appender name="STDOUT" target="System.out" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>[%date{ISO8601}] [%level] [%logger] [%thread] [%X{akkaSource}] - %msg%n</pattern>
+            <pattern>[%date{ISO8601}] [%level] [%logger] [%thread] [%X{pekkoSource}] - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/scala/src/main/scala/liftpasspricing/LiftPassPricing.scala
+++ b/scala/src/main/scala/liftpasspricing/LiftPassPricing.scala
@@ -1,11 +1,11 @@
 package liftpasspricing
 
-import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
-import akka.http.scaladsl.model.ContentTypes.`application/json`
-import akka.http.scaladsl.model.HttpEntity
-import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server.Route
 import liftpasspricing.JsonFormats._
+import org.apache.pekko.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import org.apache.pekko.http.scaladsl.model.ContentTypes.`application/json`
+import org.apache.pekko.http.scaladsl.model.HttpEntity
+import org.apache.pekko.http.scaladsl.server.Directives._
+import org.apache.pekko.http.scaladsl.server.Route
 
 import java.sql.{Connection, DriverManager}
 import java.time.LocalDate

--- a/scala/src/main/scala/liftpasspricing/WebServer.scala
+++ b/scala/src/main/scala/liftpasspricing/WebServer.scala
@@ -1,9 +1,9 @@
 package liftpasspricing
 
-import akka.actor.typed.ActorSystem
-import akka.actor.typed.scaladsl.Behaviors
-import akka.http.scaladsl.Http
-import akka.http.scaladsl.server.Route
+import org.apache.pekko.actor.typed.ActorSystem
+import org.apache.pekko.actor.typed.scaladsl.Behaviors
+import org.apache.pekko.http.scaladsl.Http
+import org.apache.pekko.http.scaladsl.server.Route
 
 import scala.util.{Failure, Success}
 

--- a/scala/src/test/resources/logback-test.xml
+++ b/scala/src/test/resources/logback-test.xml
@@ -1,8 +1,9 @@
 <configuration>
-
+    <!-- This is a development logging configuration that logs to standard out, for an example of a production
+        logging config, see the Pekko docs: https://pekko.apache.org/docs/pekko/current/typed/logging.html#logback -->
     <appender name="STDOUT" target="System.out" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>[%date{ISO8601}] [%level] [%logger] [%thread] [%X{akkaSource}] - %msg%n</pattern>
+            <pattern>[%date{ISO8601}] [%level] [%logger] [%thread] [%X{pekkoSource}] - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/scala/src/test/scala/liftpasspricing/LiftPassPricingSpec.scala
+++ b/scala/src/test/scala/liftpasspricing/LiftPassPricingSpec.scala
@@ -1,9 +1,9 @@
 package liftpasspricing
 
-import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
-import akka.http.scaladsl.server.Route
-import akka.http.scaladsl.testkit.ScalatestRouteTest
 import liftpasspricing.JsonFormats._
+import org.apache.pekko.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import org.apache.pekko.http.scaladsl.server.Route
+import org.apache.pekko.http.scaladsl.testkit.ScalatestRouteTest
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers._
 

--- a/scala/src/test/scala/liftpasspricing/LiftPassPricingSpec.scala
+++ b/scala/src/test/scala/liftpasspricing/LiftPassPricingSpec.scala
@@ -23,8 +23,8 @@ class LiftPassPricingSpec extends AnyFunSpec with ScalatestRouteTest {
       withPrices { app =>
         Get("/prices?type=1jour") ~> app ~> check {
 
-          val exptectedResult = Cost(35) // change this to make the test pass
-          responseAs[Cost] shouldBe exptectedResult
+          val expectedResult = Cost(35) // change this to make the test pass
+          responseAs[Cost] shouldBe expectedResult
         }
       }
     }


### PR DESCRIPTION
This pull request update dependencies.
It also change from [akka](https://akka.io) to [apache pekko](https://pekko.apache.org) because [akka is no longer open source](https://www.lightbend.com/akka/license-faq).

Changes are validated because once merged into `with_tests` branch on my fork, [everything is still ok](https://github.com/seblm/Refactoring-Kata-Lift-Pass-Pricing/actions/runs/5829022772).