### PR TITLE
Bugfix/fix sqlite holidays and excess data

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,6 +1,6 @@
 # Python version of Lift Pass Pricing Kata
 
-As with the other language versions, this exercise requires a database. There is a description in the [top level README](../README.md) of how to set up MySQL. If you don't have that, this version should fall back on sqlite3, and create a local database file 'lift_pass.db' in the directory where you run the application. Unfortunately the code doesn't actually work properly with sqlite3, so you'll have to adjust the SQL statements in prices.py.
+As with the other language versions, this exercise requires a database. There is a description in the [top level README](../README.md) of how to set up MySQL. If you don't have that, this version should fall back on sqlite3, and create a local database file 'lift_pass.db' in the directory where you run the application.
 
 For this python version you will also need to install the dependencies. I recommend you install them in a virtual environment like this:
 

--- a/python/src/db.py
+++ b/python/src/db.py
@@ -20,6 +20,16 @@ def create_lift_pass_db_connection(connection_options):
 def try_to_connect_with_sqlite3(connection_options):
     import sqlite3
     connection = sqlite3.connect("lift_pass.db")
+    try:
+        connection.execute(
+            'SELECT * FROM holidays '
+            'WHERE holiday = 2019-03-04'
+        )
+    except sqlite3.OperationalError:
+        pass
+    else:
+        return connection
+
     create_statements = [
         """CREATE TABLE IF NOT EXISTS base_price (
             pass_id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/python/src/db.py
+++ b/python/src/db.py
@@ -48,6 +48,7 @@ def try_to_connect_with_sqlite3(connection_options):
     ]
     for statement in create_statements:
         connection.execute(statement)
+        connection.commit()
 
     return connection
 

--- a/python/src/prices.py
+++ b/python/src/prices.py
@@ -46,6 +46,8 @@ def prices():
                     holiday = row[0]
                     if "date" in request.args:
                         d = datetime.fromisoformat(request.args["date"])
+                        if not isinstance(holiday, datetime):
+                            holiday = datetime.fromisoformat(holiday)
                         if d.year == holiday.year and d.month == holiday.month and holiday.day == d.day:
                             is_holiday = True
                 if not is_holiday and "date" in request.args and datetime.fromisoformat(request.args["date"]).weekday() == 0:


### PR DESCRIPTION
## Sqlite

This fixes the issue where the sqlite database was not getting populated by anything other than the base_price table.

In sqlite, an INSERT statement implicitly opens a transaction, which needs to be committed before changes are saved in the database.

I added the commit command to do so and updated the documentation.

## Duplicating data on each `sqlite` connection

Every time the code connects to a sqlite database, it adds the same data to the database.

This is one way to fix that by trying to query the last piece of data expected in the database. If it's there, it returns early. Otherwise it'll run the code to add all the data.

## Fix: holidays throw "string has no attribute year"
When a request is for a day pass and has a date, the logic it tries to compare the request's date to the date that comes from the database.

However, when sqlite pulls data out of the database, it's a string. It needs to be converted to a datetime object.

This is one way to fix this issue. I'm very open to other suggestions.
